### PR TITLE
Support for text field type conversion

### DIFF
--- a/patternbuilder.install
+++ b/patternbuilder.install
@@ -96,6 +96,11 @@ function patternbuilder_modules_enabled($modules) {
  *   The field name to convert.
  * @param string $field_type_new
  *   The new field type.
+ *
+ * @return bool|null
+ *   TRUE if the text field was converted or already converted.
+ *   FALSE if the conversion failed.
+ *   NULL if there was invalid information provided.
  */
 function patternbuilder_convert_text_field($field_name, $field_type_new) {
   $field_original = field_info_field($field_name);
@@ -174,12 +179,13 @@ function patternbuilder_convert_text_field($field_name, $field_type_new) {
   );
   $field['indexes'] += $field_schema['indexes'];
 
-  // Get the storage schema in case it's differnt than the field schema.
+  // Get the storage schema in case it's different than the field schema.
   $storage_schema = _field_sql_storage_schema($field);
   if (empty($storage_schema)) {
     return FALSE;
   }
 
+  $transaction = NULL;
   $have_transactional_support = Database::getConnection()->supportsTransactionalDDL();
   if ($have_transactional_support) {
     // If the database supports transactional DDL, we can go ahead and rely
@@ -229,8 +235,8 @@ function patternbuilder_convert_text_field($field_name, $field_type_new) {
     $field_config_primary_key = array('id');
     drupal_write_record('field_config', $field, $field_config_primary_key);
 
-    // Clear caches
-    field_cache_clear(TRUE);
+    // Clear caches.
+    field_cache_clear();
 
     // Invoke external hooks after the cache is cleared for API consistency.
     // See field_update_field().
@@ -332,8 +338,8 @@ function patternbuilder_convert_text_field($field_name, $field_type_new) {
       }
     }
 
-    // Clear caches
-    field_cache_clear(TRUE);
+    // Clear caches.
+    field_cache_clear();
   }
 
   return $converted;

--- a/patternbuilder.install
+++ b/patternbuilder.install
@@ -79,6 +79,267 @@ function patternbuilder_modules_enabled($modules) {
 }
 
 /**
+ * Helper function to convert "text" to "text_long" fields.
+ *
+ * Usage: Update functions to convert a text field before importing JSON schema
+ * changes.
+ *
+ * Allowed conversions:
+ * - 'text' TO 'text_long' or 'text_with_summary'.
+ * - 'text_long' TO 'text_with_summary'
+ * - 'text_with_summary' TO 'text_long': The 'summary' column is kept.
+ *
+ * The text_long or text_with_summary to text is not allowed since data could
+ * be truncated in the conversion of the value column.
+ *
+ * @param string $field_name
+ *   The field name to convert.
+ * @param string $field_type_new
+ *   The new field type.
+ */
+function patternbuilder_convert_text_field($field_name, $field_type_new) {
+  $field_original = field_info_field($field_name);
+
+  // Return if the field is the new type.
+  if ($field_original['type'] == $field_type_new) {
+    return TRUE;
+  }
+
+  // Exit if there is no field or no field type.
+  if (empty($field_original['type']) || empty($field_original['storage']['type'])) {
+    return NULL;
+  }
+
+  // Limit to text field types.
+  $allowed_types = array('text', 'text_long', 'text_with_summary');
+  if (!in_array($field_original['type'], $allowed_types, TRUE)) {
+    return NULL;
+  }
+
+  // Allowed conversions: [original type => new types allowed].
+  $allowed_conversions = array(
+    'text' => array('text_long', 'text_with_summary'),
+    'text_long' => array('text_with_summary'),
+    'text_with_summary' => array('text_long'),
+  );
+  if (!isset($allowed_conversions[$field_original['type']]) || !in_array($field_type_new, $allowed_conversions[$field_original['type']])) {
+    return NULL;
+  }
+
+  // Only SQL storage is supported.
+  if ($field_original['storage']['type'] != 'field_sql_storage' ||
+      empty($field_original['storage']['module']) ||
+      !module_exists($field_original['storage']['module'])) {
+    return NULL;
+  }
+
+  // Determine if the field has data.
+  $has_data = field_has_data($field_original);
+
+  // Create new field info.
+  $field = $field_original;
+  $field['type'] = $field_type_new;
+
+  // Include required files.
+  module_load_include('inc', 'field', 'field.info');
+  module_load_install($field['module']);
+
+  // Get type info with defaults.
+  $field_type_new_info = field_info_field_types($field_type_new);
+  if (!empty($field_type_new_info['settings'])) {
+    if (!empty($field['settings'])) {
+      $field['settings'] += $field_type_new_info['settings'];
+    }
+    else {
+      $field['settings'] = $field_type_new_info['settings'];
+    }
+  }
+
+  // Collect field storage information.
+  // See field_create_field().
+  $field_schema = (array) module_invoke($field['module'], 'field_schema', $field);
+  $field_schema += array(
+    'columns' => array(),
+    'indexes' => array(),
+    'foreign keys' => array(),
+  );
+  // 'columns' are hardcoded in the field type.
+  $field['columns'] = $field_schema['columns'];
+  // 'foreign keys' are hardcoded in the field type.
+  $field['foreign keys'] = $field_schema['foreign keys'];
+  // 'indexes' can be both hardcoded in the field type, and specified in the
+  // incoming $field definition.
+  $field += array(
+    'indexes' => array(),
+  );
+  $field['indexes'] += $field_schema['indexes'];
+
+  // Get the storage schema in case it's differnt than the field schema.
+  $storage_schema = _field_sql_storage_schema($field);
+  if (empty($storage_schema)) {
+    return FALSE;
+  }
+
+  $have_transactional_support = Database::getConnection()->supportsTransactionalDDL();
+  if ($have_transactional_support) {
+    // If the database supports transactional DDL, we can go ahead and rely
+    // on it. If not, we will have to rollback manually if something fails.
+    $transaction = db_transaction();
+  }
+
+  $converted = FALSE;
+  try {
+    // Update the field storage tables.
+    // Text fields all have the same indexes so this only needs to update the
+    // field schema columns.
+    // Note: This only updates or adds columns. It does not remove columns.
+    // If converting to a type that has fewer columns, then the original
+    // columns will remain.
+    foreach ($storage_schema as $table_name => $table_schema) {
+      foreach ($field['columns'] as $field_column_name => $field_attributes) {
+        $column_name = _field_sql_storage_columnname($field['field_name'], $field_column_name);
+        if (isset($table_schema['fields'][$column_name])) {
+          if (db_field_exists($table_name, $column_name)) {
+            db_change_field($table_name, $column_name, $column_name, $table_schema['fields'][$column_name]);
+          }
+          else {
+            db_add_field($table_name, $column_name, $table_schema['fields'][$column_name]);
+          }
+        }
+      }
+    }
+
+    // Tell the storage engine to update the field. Do this before
+    // saving the new definition since it still might fail.
+    $storage_type = field_info_storage_types($field['storage']['type']);
+    module_invoke($storage_type['module'], 'field_storage_update_field', $field, $field_original, $has_data);
+
+    // Update the field config.
+    // The serialized 'data' column contains everything from $field that does not
+    // have its own column and is not automatically populated when the field is
+    // read.
+    $data = $field;
+    unset($data['columns'], $data['field_name'], $data['type'], $data['locked'], $data['module'], $data['cardinality'], $data['active'], $data['deleted']);
+    // Additionally, do not save the 'bundles' property populated by
+    // field_info_field().
+    unset($data['bundles']);
+
+    $field['data'] = $data;
+
+    $field_config_primary_key = array('id');
+    drupal_write_record('field_config', $field, $field_config_primary_key);
+
+    // Clear caches
+    field_cache_clear(TRUE);
+
+    // Invoke external hooks after the cache is cleared for API consistency.
+    // See field_update_field().
+    module_invoke_all('field_update_field', $field, $field_original, $has_data);
+
+    $converted = TRUE;
+  }
+  catch (Exception $e) {
+    if ($have_transactional_support) {
+      $transaction->rollback();
+    }
+    else {
+      throw $e;
+    }
+  }
+
+  // Update field instances.
+  if ($converted) {
+    $field_map = field_info_field_map();
+    if (!empty($field_map[$field_name]['bundles'])) {
+      $allowed_widgets = array();
+      foreach (field_info_widget_types() as $widget_name => $widget_type) {
+        if (in_array($field_type_new, $widget_type['field types'], TRUE)) {
+          $allowed_widgets[$widget_name] = array(
+            'type' => $widget_name,
+            'active' => 1,
+            'settings' => !empty($widget_type['settings']) ? $widget_type['settings'] : array(),
+          );
+        }
+      }
+
+      $allowed_formatters = array();
+      foreach (field_info_formatter_types() as $formatter_name => $formatter) {
+        if (in_array($field_type_new, $formatter['field types'], TRUE)) {
+          $allowed_formatters[$formatter_name] = array(
+            'type' => $formatter_name,
+            'settings' => !empty($formatter['settings']) ? $formatter['settings'] : array(),
+          );;
+        }
+      }
+
+      $instance_new = array(
+        'settings' => array(),
+        'widget' => array(
+          'active' => 1,
+          'settings' => array(),
+        ),
+        'display' => array(),
+      );
+
+      if (!empty($field_type_new_info['instance_settings'])) {
+        $instance_new['settings'] = $field_type_new_info['instance_settings'];
+      }
+
+      if (!empty($field_type_new_info['default_widget']) && isset($allowed_widgets[$field_type_new_info['default_widget']])) {
+        $instance_new['widget'] = $allowed_widgets[$field_type_new_info['default_widget']];
+      }
+      elseif ($allowed_widgets) {
+        $instance_new['widget'] = reset($allowed_widgets);
+      }
+
+      if (!empty($field_type_new_info['default_formatter']) && isset($allowed_formatters[$field_type_new_info['default_formatter']])) {
+        $instance_new['display']['default'] = $allowed_formatters[$field_type_new_info['default_formatter']];
+      }
+      elseif ($allowed_formatters) {
+        $instance_new['display']['default'] = reset($allowed_formatters);
+      }
+
+      foreach ($field_map[$field_name]['bundles'] as $entity_type => $entity_bundles) {
+        foreach ($entity_bundles as $entity_bundle) {
+          $instances = field_info_instances($entity_type, $entity_bundle);
+          foreach ($instances as $instance) {
+            // Settings.
+            if (empty($instance['settings'])) {
+              $instance['settings'] = $instance_new['settings'];
+            }
+            else {
+              $instance['settings'] += $instance_new['settings'];
+            }
+
+            // Widget.
+            if (empty($instance['widget']['type']) || !isset($allowed_widgets[$instance['widget']['type']])) {
+              $instance['widget'] = $instance_new['widget'];
+            }
+
+            // Formatter.
+            if (!empty($instance['display'])) {
+              foreach ($instance['display'] as $view_mode => $display) {
+                if (empty($display['type']) || !isset($allowed_formatters[$display['type']])) {
+                  $instance['display'][$view_mode] = $instance_new['display']['default'];
+                }
+              }
+            }
+
+            // Update.
+            field_update_instance($instance);
+          }
+        }
+      }
+    }
+
+    // Clear caches
+    field_cache_clear(TRUE);
+  }
+
+  return $converted;
+}
+
+/**
  * Increase machine name field, add bundle and pattern type fields.
  */
 function patternbuilder_update_7101() {

--- a/patternbuilder.module
+++ b/patternbuilder.module
@@ -951,6 +951,56 @@ function _patternbuilder_field_info_instances($entity_type, $bundle_name) {
 }
 
 /**
+ * Finds the field instance for given property in a given component.
+ *
+ * Only a single bundle level is supported. This does not attempt to chain
+ * into fields that are field collections or paragraphs.
+ *
+ * @param string $component_machine_name
+ *   The machine name of the component schema.
+ * @param string|array $property_names
+ *   The property name or an array of property names representing the
+ *   hierarchical property stucture with the last item being the desired
+ *   property name.
+ *
+ * @return array|null
+ *   The field instance info array if found.
+ */
+function patternbuilder_field_info_property_instance($component_machine_name, $property_names) {
+  if (is_string($property_names)) {
+    $property_names = array($property_names);
+  }
+  elseif (!is_array($property_names)) {
+    return NULL;
+  }
+
+  $component = patternbuilder_components_load($component_machine_name);
+  if (empty($component->bundle_name)) {
+    return NULL;
+  }
+
+  $entity_type = 'paragraphs_item';
+  $bundle_name = $component->bundle_name;
+  $instances = _patternbuilder_field_info_instances($entity_type, $bundle_name);
+  if (empty($instances)) {
+    return NULL;
+  }
+
+  // Note: only a single bundle level is supported. This does not attempt to
+  // chain into fields that are field collections or paragraphs.
+  $property_name = array_pop($property_names);
+  $parent_names = $property_names ? implode(PATTERNBUILDER_PROPERTY_DELIMITER, $property_names) : '';
+  foreach ($instances as $field_name => $instance) {
+    $settings = _patternbuilder_field_instance_settings($instance, TRUE);
+    if ($settings['real_property_name'] == $property_name) {
+      if (!$parent_names || $parent_names == $settings['parent_property_names']) {
+        return $instance;
+      }
+    }
+  }
+}
+
+/**
  * Determines if an entity is considered to be a tuple.
  *
  * If there is at least 1 non-tuple item property field then none are returned.

--- a/patternbuilder.module
+++ b/patternbuilder.module
@@ -960,7 +960,7 @@ function _patternbuilder_field_info_instances($entity_type, $bundle_name) {
  *   The machine name of the component schema.
  * @param string|array $property_names
  *   The property name or an array of property names representing the
- *   hierarchical property stucture with the last item being the desired
+ *   hierarchical property structure with the last item being the desired
  *   property name.
  *
  * @return array|null


### PR DESCRIPTION
Added 2 helper functions to be used in site update functions:
1. patternbuilder_convert_text_field() - Convert a text field to another type. Example: text to text_long.
2. patternbuilder_field_info_property_instance() - Find a Drupal field instance based on the schema property name.

Example update:

``` php
/**
 * Convert card footer summary from text to text_long.
 */
function my_module_update_7168() {
  $pattern_name = 'card';
  $property_names = array('footer', 'summary');
  $field_type_new = 'text_long';

  $converted = FALSE;
  $instance = patternbuilder_field_info_property_instance($pattern_name, $property_names);
  if (!empty($instance['field_name'])) {
    module_load_install('patternbuilder');
    $converted = patternbuilder_convert_text_field($instance['field_name'], $field_type_new);
  }
}
```
